### PR TITLE
Changed Max Durability Drain Rate being limited to 1.

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -7,7 +7,7 @@ using EFT;
 
 namespace armorMod
 {
-    [BepInPlugin("com.dvize.ASS", "dvize.ASS", "1.3.0")]
+    [BepInPlugin("com.dvize.ASS", "dvize.ASS", "1.3.1")]
 
     public class AssPlugin : BaseUnityPlugin
     {
@@ -75,7 +75,7 @@ namespace armorMod
             ArmorRepairRateOverTime = Config.Bind("Armor Repair Settings", "Armor Repair Rate", 0.5f, new ConfigDescription("How much durability per second is repaired",
                 new AcceptableValueRange<float>(0f, 10f), new ConfigurationManagerAttributes { IsAdvanced = false, Order = 4 }));
             MaxDurabilityDegradationRateOverTime = Config.Bind("Armor Repair Settings", "Max Durability Drain Rate", 0.025f, new ConfigDescription("How much max durability per second of repairs is drained",
-                new AcceptableValueRange<float>(0f, 1f), new ConfigurationManagerAttributes { IsAdvanced = false, Order = 3 }));
+                new AcceptableValueRange<float>(0f, 100f), new ConfigurationManagerAttributes { IsAdvanced = false, Order = 3 }));
             MaxDurabilityCap = Config.Bind("Armor Repair Settings", "Max Durability Cap", 100f, new ConfigDescription("Maximum durability percentage to which armor will be able to repair to. For example, setting to 80 would repair your armor to maximum of 80% of it's max durability",
                 new AcceptableValueRange<float>(0f, 100f), new ConfigurationManagerAttributes { IsAdvanced = false, Order = 2 }));
 
@@ -84,7 +84,7 @@ namespace armorMod
             weaponRepairRateOverTime = Config.Bind("Weapon Repair Settings", "Weapon Repair Rate", 0.5f, new ConfigDescription("How much durability per second is repaired",
                 new AcceptableValueRange<float>(0f, 10f), new ConfigurationManagerAttributes { IsAdvanced = false, Order = 4 }));
             weaponMaxDurabilityDegradationRateOverTime = Config.Bind("Weapon Repair Settings", "Max Durability Drain Rate", 0f, new ConfigDescription("How much max durability per second of repairs is drained (set really low if using)",
-                new AcceptableValueRange<float>(0f, 1f), new ConfigurationManagerAttributes { IsAdvanced = false, Order = 3 }));
+                new AcceptableValueRange<float>(0f, 100f), new ConfigurationManagerAttributes { IsAdvanced = false, Order = 3 }));
             weaponMaxDurabilityCap = Config.Bind("Weapon Repair Settings", "Max Durability Cap", 100f, new ConfigDescription("Maximum durability percentage to which weapon will be able to repair to. For example, setting to 80 would repair your armor to maximum of 80% of it's max durability",
                 new AcceptableValueRange<float>(0f, 100f), new ConfigurationManagerAttributes { IsAdvanced = false, Order = 2 }));
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyFileVersion("1.3.1.0")]


### PR DESCRIPTION
Max Durability Drain is flat drain, it's not %-based. With current settings you can have max durability drain per second between 0 and 1 durability. So if someone wanted to set up their armor repair rate, for example, being 30/second and as drawback they would want to have armor drain 5/second, they wouldn't be able to.